### PR TITLE
Copy file path with UTF-8 characters

### DIFF
--- a/copyfilepath.py
+++ b/copyfilepath.py
@@ -29,7 +29,7 @@ class CopyFilePathPlugin:
 
     def copy_to_clipboard(self, file_path):
         clipboard = Gtk.Clipboard.get_default(Gdk.Display.get_default())
-        Gtk.Clipboard.set_text(clipboard, file_path, len(file_path))
+        Gtk.Clipboard.set_text(clipboard, file_path, -1)
         clipboard.store()
 
     def document_loaded(self, document):


### PR DESCRIPTION
Copy file path with UTF-8 characters.

Fixes #1.